### PR TITLE
Interesting discussion on memory issue on rugged

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ Other questions will follow
 * [Documenting Ruby memory model](https://bugs.ruby-lang.org/issues/12020)
 * [Decreased Object Allocation in Pathname.rb](https://bugs.ruby-lang.org/issues/11375)
 * [Derailed benchmark explanations](https://github.com/schneems/derailed_benchmarks/issues/62)
+* [libgit2/rugged - Memory leak caused by diffs?](https://github.com/libgit2/rugged/issues/695#issuecomment-308582965)
 
 #### Book :
 * [Ruby under microscope](http://patshaughnessy.net/ruby-under-a-microscope)


### PR DESCRIPTION
Very interesting discussion between tenderlove and alyssais about memory footprint in libgit2/rugged. Lot's of code to reproduce behavior or memory that keep increasing. Tenderlove use `MallocStackLoggingNoCompact` to record all call to `malloc` regardless of requested size, along with the stack trace of the malloc call. That's 👌🏼